### PR TITLE
Fixed: Makefile and segfault error on load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SLUG = PulsumQuadratum-SDR
 VERSION = 0.6.0
 
+# If RACK_DIR is not defined when calling the Makefile, default to two levels above
+RACK_DIR ?= ../..
+
 PKGCONFIG= pkg-config
 PACKAGES= libusb-1.0 librtlsdr
 
@@ -13,7 +16,7 @@ CXXFLAGS +=
 SOURCES = $(wildcard src/*.cpp src/*.c src/*/*.cpp src/*/*.c)
 
 # Must include the VCV plugin Makefile framework
-include ../../plugin.mk
+include ../../arch.mk
 
 # Careful about linking to libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine.
@@ -33,9 +36,6 @@ ifeq ($(ARCH), win)
 endif
 
 DISTRIBUTABLES += $(wildcard LICENSE*) res
-
-# If RACK_DIR is not defined when calling the Makefile, default to two levels above
-RACK_DIR ?= ../..
 
 # Include the VCV Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS +=
 SOURCES = $(wildcard src/*.cpp src/*.c src/*/*.cpp src/*/*.c)
 
 # Must include the VCV plugin Makefile framework
-include ../../arch.mk
+include $(RACK_DIR)/arch.mk
 
 # Careful about linking to libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine.

--- a/src/sdr/SDR.cpp
+++ b/src/sdr/SDR.cpp
@@ -52,6 +52,7 @@ struct SDR : Module {
 
 	SDR() : Module(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS) {
 		buffer.clear();
+		RtlSdr_init(&radio, (int)engineGetSampleRate());
   }
 	~SDR() {
 		RtlSdr_end(&radio);


### PR DESCRIPTION
@WIZARDISHUNGRY Hi Jon, just uploaded the quick-fix to segfault error onto my forked repo. 
I also noticed a mismatch in Makefile, there was a duplicate line including plugin.mk. The first include directive had to point to arch.mk (the mismatch caused a build error too). I also moved the RACK_DIR definition on top of the file. 
I send you a PR, but simlpy take it as an issue at your wish. Regards