### PR TITLE
Migration to Rack V1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKGCONFIG= pkg-config
 PACKAGES= libusb-1.0 librtlsdr
 
 # FLAGS will be passed to both the C and C++ compiler
-FLAGS += $(shell $(PKGCONFIG) --cflags $(PACKAGES))
+FLAGS += $(shell $(PKGCONFIG) --cflags $(PACKAGES)) -w
 CFLAGS +=
 CXXFLAGS +=
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-SLUG = PulsumQuadratum-SDR
-VERSION ?= 0.6.0dev
-
 # If RACK_DIR is not defined when calling the Makefile, default to two levels above
 RACK_DIR ?= ../..
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PKGCONFIG= pkg-config
 PACKAGES= libusb-1.0 librtlsdr
 
 # FLAGS will be passed to both the C and C++ compiler
-FLAGS += $(shell $(PKGCONFIG) --cflags $(PACKAGES)) -w
+FLAGS += $(shell $(PKGCONFIG) --cflags $(PACKAGES))
 CFLAGS +=
 CXXFLAGS +=
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,25 @@
+{
+  "slug": "PulsumQuadratum-SDR",
+  "name": "Pulsum Quadratum",
+  "version": "1.0.0",
+  "license": " GPL-2.0-only",
+  "brand": "PulsumQuadratum-SDR",
+  "author": "bongozone",
+  "authorEmail": "",
+  "authorUrl": "https://bongo.zone/",
+  "pluginUrl": "https://bongo.zone/modules/rtl-sdr",
+  "manualUrl": "https://bongo.zone/modules/rtl-sdr",
+  "sourceUrl": "https://github.com/bongozone/vcvrack-rtlsdr",
+  "donateUrl": "",
+  "changelogUrl": "",
+  "modules": [
+    {
+      "slug": "SDRWidget",
+      "name": "SDRWidget",
+      "description": "rtl-sdr FM Radio Tuner",
+      "tags": [
+        "Tuner"
+      ]
+    }
+  ]
+}

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "license": " GPL-2.0-only",
   "brand": "PulsumQuadratum-SDR",
-  "author": "bongozone",
+  "author": "Jon Williams",
   "authorEmail": "",
   "authorUrl": "https://bongo.zone/",
   "pluginUrl": "https://bongo.zone/modules/rtl-sdr",

--- a/res/sdr.svg
+++ b/res/sdr.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 60 380"
+   version="1.1"
+   id="svg268"
+   sodipodi:docname="sdr.svg"
+   width="60"
+   height="380"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata274">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>panel</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs272" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="768"
+     id="namedview270"
+     showgrid="false"
+     inkscape:zoom="0.62105263"
+     inkscape:cx="114.74576"
+     inkscape:cy="190"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg268" />
+  <title
+     id="title2">panel</title>
+  <rect
+     style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.88968623;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.24157476;stroke-opacity:1"
+     id="rect1081"
+     width="60"
+     height="380"
+     x="0"
+     y="0" />
+</svg>

--- a/src/PQ.cpp
+++ b/src/PQ.cpp
@@ -5,14 +5,5 @@ Plugin *plugin;
 
 void init(rack::Plugin *p) {
 	plugin = p;
-	// This is the unique identifier for your plugin
-	p->slug = "PulsumQuadratum-SDR";
-#ifdef VERSION
-	p->version = TOSTRING(VERSION);
-#endif
-	p->website = "https://github.com/WIZARDISHUNGRY/vcvrack-plugins";
-	p->manual = "https://github.com/WIZARDISHUNGRY/vcvrack-plugins/README.md";
-
 	p->addModel(sdrModule);
-
 }

--- a/src/PQ.cpp
+++ b/src/PQ.cpp
@@ -1,9 +1,9 @@
 #include "PQ.hpp"
 
-// The plugin-wide instance of the Plugin class
-Plugin *plugin;
+// The pluginInstance-wide instance of the Plugin class
+Plugin *pluginInstance;
 
 void init(rack::Plugin *p) {
-	plugin = p;
+	pluginInstance = p;
 	p->addModel(sdrModule);
 }

--- a/src/PQ.hpp
+++ b/src/PQ.hpp
@@ -1,4 +1,4 @@
-#include "rack0.hpp"
+#include "rack.hpp"
 
 using namespace rack;
 

--- a/src/PQ.hpp
+++ b/src/PQ.hpp
@@ -1,4 +1,4 @@
-#include "rack.hpp"
+#include "rack0.hpp"
 
 using namespace rack;
 

--- a/src/PQ.hpp
+++ b/src/PQ.hpp
@@ -3,7 +3,7 @@
 using namespace rack;
 
 
-extern Plugin *plugin;
+extern Plugin *pluginInstance;
 
 ////////////////////
 // module widgets

--- a/src/sdr/SDR.cpp
+++ b/src/sdr/SDR.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <iomanip> // setprecision
 #include <sstream> // stringstream
-#include "dsp/ringbuffer.hpp"
 #define HZ_CEIL 110.0
 #define HZ_FLOOR 80.0
 #define HZ_SPAN (HZ_CEIL-HZ_FLOOR)
@@ -164,18 +163,21 @@ SDRWidget::SDRWidget(SDR *module) : ModuleWidget(module) {
 
 	box.size = Vec(4 * RACK_GRID_WIDTH, RACK_GRID_HEIGHT);
 
-  Panel *panel = new LightPanel();
+  // Panel *panel = new LightPanel();
+  SVGPanel *panel = new SVGPanel();
   panel->box.size = box.size;
+  panel->setBackground(APP->window->loadSvg(asset::plugin(pluginInstance, "res/sdr.svg")));
   addChild(panel);
 
-	addChild(Widget::create<ScrewSilver>(Vec(0, 0)));
-	addChild(Widget::create<ScrewSilver>(Vec(0, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
+	addChild(createWidget<ScrewSilver>(Vec(0, 0)));
+	addChild(createWidget<ScrewSilver>(Vec(0, RACK_GRID_HEIGHT - RACK_GRID_WIDTH)));
 
 	{
 		MyLabel* const freqLabel = new MyLabel;
 		freqLabel->box.pos = Vec(box.size.x/4,RACK_GRID_WIDTH*3);  // coordinate system is broken FIXME
 		freqLabel->text = "0";
-		module->linkedLabel = freqLabel;
+    if(module)
+      module->linkedLabel = freqLabel;
 		addChild(freqLabel);
 	}
 
@@ -202,13 +204,13 @@ SDRWidget::SDRWidget(SDR *module) : ModuleWidget(module) {
 		addChild(cLabel);
 	}
 
-  SVGKnob *knob = dynamic_cast<SVGKnob*>(ParamWidget::create<RoundHugeBlackKnob>(Vec(RACK_GRID_WIDTH/6, 100), module, SDR::TUNE_PARAM, HZ_FLOOR, HZ_CEIL, HZ_CENTER));
+  SVGKnob *knob = dynamic_cast<SVGKnob*>(createParam<RoundHugeBlackKnob>(Vec(RACK_GRID_WIDTH/6, 100), module, SDR::TUNE_PARAM, HZ_FLOOR, HZ_CEIL, HZ_CENTER));
 	knob->maxAngle += 10*2*M_PI;
 	knob->speed /= 20.f;
 	addParam(knob);
-	addParam(ParamWidget::create<RoundSmallBlackKnob>(Vec(RACK_GRID_WIDTH, 170), module, SDR::TUNE_ATT, -HZ_SPAN/2.0, +HZ_SPAN/2.0, 0.0));
-	addInput(Port::create<PJ301MPort>(Vec(RACK_GRID_WIDTH, 200), Port::INPUT, module, SDR::TUNE_INPUT));
-	addParam(ParamWidget::create<CKSSThree>(Vec(RACK_GRID_WIDTH/2, 240), module, SDR::QUANT_PARAM, 0.0, 2.0, 0.0));
+	addParam(createParam<RoundSmallBlackKnob>(Vec(RACK_GRID_WIDTH, 170), module, SDR::TUNE_ATT, -HZ_SPAN/2.0, +HZ_SPAN/2.0, 0.0));
+	addInput(createPort<PJ301MPort>(Vec(RACK_GRID_WIDTH, 200), PortWidget::INPUT, module, SDR::TUNE_INPUT));
+	addParam(createParam<CKSSThree>(Vec(RACK_GRID_WIDTH/2, 240), module, SDR::QUANT_PARAM, 0.0, 2.0, 0.0));
 	{
 		MyLabel* const cLabel = new MyLabel(12);
 		cLabel->box.pos = Vec(16,236/2); // coordinate system is broken FIXME
@@ -239,8 +241,8 @@ SDRWidget::SDRWidget(SDR *module) : ModuleWidget(module) {
 	}
 
 
-	addOutput(Port::create<PJ301MPort>(Vec(RACK_GRID_WIDTH, box.size.y-3*RACK_GRID_WIDTH), Port::OUTPUT, module, SDR::AUDIO_OUT));
+	addOutput(createPort<PJ301MPort>(Vec(RACK_GRID_WIDTH, box.size.y-3*RACK_GRID_WIDTH), PortWidget::OUTPUT, module, SDR::AUDIO_OUT));
 }
 
 
-Model *sdrModule = Model::create<SDR, SDRWidget>("SDRWidget");
+Model *sdrModule = createModel<SDR, SDRWidget>("SDRWidget");

--- a/src/sdr/SDR.cpp
+++ b/src/sdr/SDR.cpp
@@ -243,5 +243,4 @@ SDRWidget::SDRWidget(SDR *module) : ModuleWidget(module) {
 }
 
 
-Model *sdrModule = Model::create<SDR, SDRWidget>(
-	"Pulsum Quadratum", "SDRWidget", "rtl-sdr FM Radio Tuner", EXTERNAL_TAG, TUNER_TAG);
+Model *sdrModule = Model::create<SDR, SDRWidget>("SDRWidget");


### PR DESCRIPTION
Migrated the module to `Rack v1.x`
Complies successfully and works flawlessly on `Rack v1.1.4` under Arch Linux with DVB-T dongle.
Added plain white panel `.svg` in order to be more in line with other modules and to get rid of `LightPanel`.