### PR TITLE
Install dependencies using vcpkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist
 build
 *.dylib
 /vcpkg_installed/
+plugin.so
+plugin.dll
+plugin.a

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 build
 *.dylib
+/vcpkg_installed/

--- a/Makefile
+++ b/Makefile
@@ -1,38 +1,44 @@
 # If RACK_DIR is not defined when calling the Makefile, default to two levels above
 RACK_DIR ?= ../..
 
-PKGCONFIG= pkg-config
-PACKAGES= libusb-1.0 librtlsdr
-
-# FLAGS will be passed to both the C and C++ compiler
-FLAGS += $(shell $(PKGCONFIG) --cflags $(PACKAGES))
-CFLAGS +=
-CXXFLAGS +=
-
-# Add .cpp and .c files to the build
-SOURCES = $(wildcard src/*.cpp src/*.c src/*/*.cpp src/*/*.c)
-
 # Must include the VCV plugin Makefile framework
 include $(RACK_DIR)/arch.mk
 
-# Careful about linking to libraries, since you can't assume much about the user's environment and library search path.
-# Static libraries are fine.
-ifeq ($(ARCH), lin)
-	# WARNING: static compilation is broken on Linux
-	LDFLAGS +=$(shell $(PKGCONFIG) --libs $(PACKAGES))
+# Assume that `vcpkg install` has run so the dependencies from `vcpkg.json` are available
+# under `vcpkg_installed` in the source dir.
+
+PKGCONFIG= pkg-config
+PACKAGES= libusb-1.0 librtlsdr
+
+# Map VCVRack's arch.mk to vcpkg's triplet
+ifeq ($(ARCH_OS), lin)
+  TRIPLET := $(ARCH_CPU)-linux
+else ifeq ($(ARCH_OS), mac)
+  TRIPLET := $(ARCH_CPU)-osx
+else ifeq ($(ARCH_OS), win)
+  TRIPLET := $(ARCH_CPU)-windows
+else
+  $(error Unrecognized OS "$(ARCH_OS)")
 endif
 
-ifeq ($(ARCH), mac)
-	LDFLAGS +=$(shell $(PKGCONFIG) --variable=libdir libusb-1.0)/libusb-1.0.a
-	LDFLAGS +=$(shell $(PKGCONFIG) --variable=libdir librtlsdr)/librtlsdr.a
-endif
+PKG_CONFIG_PATH = $(abspath vcpkg_installed)/$(TRIPLET)/lib/pkgconfig
+PKGCONFIG := $(abspath vcpkg_installed)/$(TRIPLET)/tools/pkgconf/pkgconf --with-path=$(PKG_CONFIG_PATH)
 
-ifeq ($(ARCH), win)
-	LDFLAGS +=$(shell $(PKGCONFIG) --variable=libdir librtlsdr)/librtlsdr_static.a
-	LDFLAGS +=$(shell $(PKGCONFIG) --variable=libdir libusb-1.0)/libusb-1.0.a
-endif
+# FLAGS will be passed to both the C and C++ compiler
+FLAGS += $(shell $(PKGCONFIG)  --cflags $(PACKAGES))
+CFLAGS +=
+CXXFLAGS +=
+LDFLAGS += $(shell $(PKGCONFIG)  --libs $(PACKAGES))
+
+# Add .cpp and .c files to the build
+SOURCES = $(wildcard src/*.cpp src/*.c src/*/*.cpp src/*/*.c)
 
 DISTRIBUTABLES += $(wildcard LICENSE*) res
 
 # Include the VCV Rack plugin Makefile framework
 include $(RACK_DIR)/plugin.mk
+
+.PHONY: vcpkg
+
+vcpkg:
+	vcpkg install --no-print-usage

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ A voltage-controlled FM radio tuner for [VCVRack](https://vcvrack.com) supportin
 [Downloads](https://vcvrack.com/plugins.html#RTL_SDR)
 
 [![Build Status](https://travis-ci.org/WIZARDISHUNGRY/vcvrack-rtlsdr.svg?branch=master)](https://travis-ci.org/WIZARDISHUNGRY/vcvrack-rtlsdr)
+
+## Build
+
+Building a package requires the VCVRack source tree. You can either check out this module inside the `plugins` directory, or build with an explicit path like
+
+    make RACK_DIR=$HOME/src/vcvrack
+
+This branch can use [vcpkg](https://learn.microsoft.com/en-us/vcpkg/) to fetch dependencies, and requires that `vcpkg` already be installed. Before building, run
+
+    make vcpkg

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "dependencies": [
+        "libusb",
+        {
+            "name": "pkgconf",
+            "host": true
+        },
+        "rtlsdr"
+    ]
+}


### PR DESCRIPTION
I thought I'd try fetching the dependencies using vcpkg, which should work across platforms and would avoid complicating this tree with details of how to fetch and build them. (However, I only tested this on Linux so far.) I think this would help with or outright fix issues like #41, #31.

I have not tried to get it working in CI.